### PR TITLE
Shared preferences async task executor

### DIFF
--- a/once/src/main/java/jonathanfinerty/once/AsyncSharedPreferenceLoader.java
+++ b/once/src/main/java/jonathanfinerty/once/AsyncSharedPreferenceLoader.java
@@ -3,17 +3,28 @@ package jonathanfinerty.once;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 
 class AsyncSharedPreferenceLoader {
 
     private final AsyncTask<String, Void, SharedPreferences> asyncTask;
 
-    AsyncSharedPreferenceLoader(Context context, String name) {
+    AsyncSharedPreferenceLoader(@NonNull Context context, @NonNull String name) {
+        this(context, null, name);
+    }
+
+    AsyncSharedPreferenceLoader(@NonNull Context context, @Nullable Executor executor, @NonNull String name) {
         asyncTask = new SharedPreferencesAsyncTask(context);
-        asyncTask.execute(name);
+        if (executor != null) {
+            asyncTask.executeOnExecutor(executor, name);
+        } else {
+            asyncTask.execute(name);
+        }
     }
 
     SharedPreferences get() {

--- a/once/src/main/java/jonathanfinerty/once/Once.java
+++ b/once/src/main/java/jonathanfinerty/once/Once.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.support.annotation.IntDef;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.lang.annotation.Retention;
@@ -11,6 +12,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import static jonathanfinerty.once.Amount.moreThan;
@@ -37,9 +39,19 @@ public class Once {
      *
      * @param context Application context
      */
-    public static void initialise(Context context) {
-        tagLastSeenMap = new PersistedMap(context, "TagLastSeenMap");
-        toDoSet = new PersistedSet(context, "ToDoSet");
+    public static void initialise(@NonNull Context context) {
+        initialise(context, null);
+    }
+
+    /**
+     * Same as previous method, but with use of shared prefs async task's executor.
+     *
+     * @param context Application context
+     * @param executor Executor executor for shared prefs async task
+     */
+    public static void initialise(@NonNull Context context, @Nullable Executor executor) {
+        tagLastSeenMap = new PersistedMap(context, executor, "TagLastSeenMap");
+        toDoSet = new PersistedSet(context, executor, "ToDoSet");
 
         if (sessionList == null) {
             sessionList = new ArrayList<>();

--- a/once/src/main/java/jonathanfinerty/once/Once.java
+++ b/once/src/main/java/jonathanfinerty/once/Once.java
@@ -44,7 +44,7 @@ public class Once {
     }
 
     /**
-     * Same as previous method, but with use of shared prefs async task's executor.
+     * Initialise using shared prefs async task's executor.
      *
      * @param context Application context
      * @param executor Executor executor for shared prefs async task

--- a/once/src/main/java/jonathanfinerty/once/PersistedMap.java
+++ b/once/src/main/java/jonathanfinerty/once/PersistedMap.java
@@ -3,12 +3,14 @@ package jonathanfinerty.once;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 
 class PersistedMap {
 
@@ -18,9 +20,13 @@ class PersistedMap {
     private final Map<String, List<Long>> map = new ConcurrentHashMap<>();
     private final AsyncSharedPreferenceLoader preferenceLoader;
 
-    PersistedMap(Context context, String mapName) {
+    PersistedMap(@NonNull Context context, @NonNull String mapName) {
+        this(context, null, mapName);
+    }
+
+    PersistedMap(@NonNull Context context, @Nullable Executor executor, @NonNull String mapName) {
         String preferencesName = "PersistedMap".concat(mapName);
-        preferenceLoader = new AsyncSharedPreferenceLoader(context, preferencesName);
+        preferenceLoader = new AsyncSharedPreferenceLoader(context, executor, preferencesName);
     }
 
     private void waitForLoad() {

--- a/once/src/main/java/jonathanfinerty/once/PersistedSet.java
+++ b/once/src/main/java/jonathanfinerty/once/PersistedSet.java
@@ -2,9 +2,12 @@ package jonathanfinerty.once;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.Executor;
 
 class PersistedSet {
 
@@ -15,9 +18,13 @@ class PersistedSet {
 
     private final AsyncSharedPreferenceLoader preferenceLoader;
 
-    PersistedSet(Context context, String setName) {
+    PersistedSet(@NonNull Context context, @NonNull String setName) {
+        this(context, null, setName);
+    }
+
+    PersistedSet(@NonNull Context context, @Nullable Executor executor, @NonNull String setName) {
         String preferencesName = "PersistedSet".concat(setName);
-        preferenceLoader = new AsyncSharedPreferenceLoader(context, preferencesName);
+        preferenceLoader = new AsyncSharedPreferenceLoader(context, executor, preferencesName);
     }
 
     private void waitForLoad() {


### PR DESCRIPTION
Using Once library, we recently encountered a problem on some android devices: SharedPreferencesAsyncTask is never called and asyncTask.get() blocking application start forever. Using asyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR) hepls to solve this problem. Merge request contains a solution.