### PR TITLE
Use explicit executor

### DIFF
--- a/once/src/main/java/jonathanfinerty/once/AsyncSharedPreferenceLoader.java
+++ b/once/src/main/java/jonathanfinerty/once/AsyncSharedPreferenceLoader.java
@@ -3,6 +3,7 @@ package jonathanfinerty.once;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
+import android.os.Build;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.ExecutionException;
@@ -13,7 +14,7 @@ class AsyncSharedPreferenceLoader {
 
     AsyncSharedPreferenceLoader(Context context, String name) {
         asyncTask = new SharedPreferencesAsyncTask(context);
-        asyncTask.execute(name);
+        asyncTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, name);
     }
 
     SharedPreferences get() {


### PR DESCRIPTION
Given only support api 14+ this hopefully is a simplier solution to #40 