### PR TITLE
Fixed PersistedSet class

### DIFF
--- a/once/src/main/java/jonathanfinerty/once/PersistedSet.java
+++ b/once/src/main/java/jonathanfinerty/once/PersistedSet.java
@@ -17,7 +17,7 @@ class PersistedSet {
     PersistedSet(Context context, String setName) {
         String preferencesName = "PersistedSet".concat(setName);
         preferences = context.getSharedPreferences(preferencesName, Context.MODE_PRIVATE);
-        set = preferences.getStringSet(STRING_SET_KEY, new HashSet<String>());
+        set = new HashSet<>(preferences.getStringSet(STRING_SET_KEY, new HashSet<String>()));
     }
 
     void put(String tag) {


### PR DESCRIPTION
The preferences StringSet should not be modified directly. We found this issue because the StringSet was not preserved after an app restart. A copy of it should be made before applying changes. 